### PR TITLE
Поддержка XeLaTeX

### DIFF
--- a/R/tikzsetup.R
+++ b/R/tikzsetup.R
@@ -21,7 +21,8 @@ NULL
 #' @examples
 #' tikzsetup()
 #' tikzsetup(lang="polish")
-tikzsetup  <- function(lang="russian", doc_class_options="10pt",
+tikzsetup  <- function(compiler="pdftex",lang="russian",
+                        doc_class_options="10pt",
                         message=FALSE, warning=FALSE) {
   Sys.setenv(LANG="EN") # Error message MUST be in english
   Sys.setlocale("LC_TIME","C") # correct work of quantmod
@@ -29,7 +30,8 @@ tikzsetup  <- function(lang="russian", doc_class_options="10pt",
   
   opts_chunk$set(dev='tikz', dpi=300, warning=warning, message=message)
   
-  options(tikzDefaultEngine = "pdftex")
+  if (compiler=="xelatex") compiler <- "xetex"
+  options(tikzDefaultEngine = compiler)
   
   options(tikzLatexPackages = c(
     "\\usepackage{amsmath,amssymb,amsfonts}",
@@ -39,6 +41,14 @@ tikzsetup  <- function(lang="russian", doc_class_options="10pt",
     paste0("\\usepackage[",lang,"]{babel}"),
     paste0("\\selectlanguage{",lang,"}"),
     "\\usepackage{standalone}"
+  ))
+  
+  options(tikzXelatexPackages=c(
+    "\\nonstopmode",
+    "\\usepackage{tikz}",
+    "\\usepackage[active,tightpage,xetex]{preview}",
+    "\\PreviewEnvironment{pgfpicture}",
+    "\\setlength\\PreviewBorder{0pt}"
   ))
   
   #options(tikzMetricsDictionary="/Users/boris/Documents/r_packages/") # speeds tikz up


### PR DESCRIPTION
Добавлена поддержка XeLaTeX путем внесения новой опции **_compiler**_ в число аргументов функции (выставлена первым аргументом, что позволяет передавать ее единственным параметром функции без названия опции).
При неявной передаче используется значение по умолчанию _pdftex_, если же потребуется использование _xetex_, достаточно будет указать его единственным аргументом функции.

Внесены изменения в опции _tikzXelatexPackages_, которые по умолчанию содержали пакет **fontenc**. В преамбуле Rnw-файла (при использовании XeLaTeX) этот пакет также указывается, что приводило к попытке его повторной загрузки и вызывало конфликт переданных аргументов, из-за чего не компилировались tikz-иллюстрации.
